### PR TITLE
Introduce bouncy castle dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,12 +51,12 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15to18</artifactId>
-            <version>1.78.1</version>
+            <version>${bouncycastle.version}</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcutil-jdk15to18</artifactId>
-            <version>1.78.1</version>
+            <version>${bouncycastle.version}</version>
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>


### PR DESCRIPTION
Added missing dependencies based on:
https://forum.prosysopc.com/forum/opc-ua-java-sdk/noclassdeffounderror-after-updating-to-5-2-4-147/#p7155